### PR TITLE
fix(play): fix in progress answer state management

### DIFF
--- a/apps/www/src/app/play/InProgress/index.tsx
+++ b/apps/www/src/app/play/InProgress/index.tsx
@@ -1,28 +1,29 @@
-import React, { useState, useEffect } from 'react';
-import { Button } from '@material-ui/core';
+import React, {
+  useState,
+  useEffect,
+} from 'react';
 import { TriviaJoiningProps } from '../symbols';
-import Timer from '../timer';
-import Nav from '../../nav';
-import Error from '../../shared/error';
-import { Attachment } from '../Attachment';
-import { Question } from '../../shared/common';
-import { Exception } from '../../shared/errors';
 import {
   answerQuestion,
   setAnswerStartTime,
 } from '../../shared/trivias.service';
+import { Button } from '@material-ui/core';
 import './index.scss';
+import Nav from '../../nav';
 import QuestionResult from '../QuestionResult';
+import Error from '../../shared/error';
+import Timer from '../timer';
+import { Attachment } from '../Attachment';
 
-const AnswerButton = ({
+const Answer = ({
   possibleAnswer,
   selectOption,
-  selected,
   answered,
+  selected,
 }: {
   possibleAnswer: string;
-  selected: boolean;
   answered: boolean;
+  selected: boolean;
   selectOption: () => void;
 }) => {
   const variant = answered && !selected ? 'outlined' : 'contained';
@@ -41,122 +42,82 @@ const AnswerButton = ({
 };
 
 const InProgress = ({ trivia, triviaId, user }: TriviaJoiningProps) => {
-  const [answerError, setAnswerError] = useState<Error | null>(null);
-  const [selectedAnswerStartTime, setSelectedAnswerStartTime] = useState<
-    number | undefined
-  >(undefined);
+  const currentQuestion = trivia.questions[trivia.currentQuestionIndex || 0];
+  const participant = trivia.participants[user.uid];
+  const currentAnswer = participant && participant.answers[trivia.currentQuestionIndex || 0];
+  const answerStartTime = currentAnswer?.startTime || undefined;
+  const selectedAnswerIndex = currentAnswer?.selectedAnswerIndex || null;
 
-  const [completed, setCompleted] = useState<boolean>(false);
-  const [question, setQuestion] = useState<Question | null>(null);
-  const [answeredIndex, setAnsweredIndex] = useState<number | null>(null);
+  const [completed, setCompleted] = useState(false);
+  const [answerError, setAnswerError] = useState<Error>();
 
-  const [currentQuestionIndex, setCurrentQuestionIndex] = useState<
-    number | null
-  >(null);
-  const [selectedAnswerIndex, setSelectedAnswerIndex] = useState<number | null>(
-    null
-  );
+  const [clickedAnswer, setClickedAnswer] = useState<number | null>(null);
 
   useEffect(() => {
-    const participant = trivia.participants[user.uid];
-    const currentAnswer =
-      participant &&
-      trivia.currentQuestionIndex !== null &&
-      participant.answers[trivia.currentQuestionIndex];
-    const answerIndex =
-      (currentAnswer && currentAnswer.selectedAnswerIndex) || null;
-    const answerStartTime =
-      (currentAnswer && currentAnswer.startTime) || undefined;
-
-    setQuestion(
-      trivia.currentQuestionIndex !== null
-        ? trivia.questions[trivia.currentQuestionIndex]
-        : null
-    );
-    setSelectedAnswerStartTime(answerStartTime);
-    setCurrentQuestionIndex(trivia.currentQuestionIndex);
-    setSelectedAnswerIndex(answerIndex);
-  }, [
-    trivia.participants,
-    trivia.currentQuestionIndex,
-    trivia.questions,
-    user.uid,
-  ]);
-
-  useEffect(() => {
-    setAnswerError(null);
     setCompleted(false);
-    setAnsweredIndex(selectedAnswerIndex);
-  }, [currentQuestionIndex, selectedAnswerIndex]);
+    setAnswerError(undefined);
+    setClickedAnswer(null);
+  }, [trivia.currentQuestionIndex, selectedAnswerIndex, clickedAnswer]);
 
   const selectOption = async (index: number) => {
-    setAnsweredIndex(index);
     try {
-      if (!currentQuestionIndex && currentQuestionIndex !== 0) {
-        throw new Exception(500, 'Question index is null.');
-      }
-
+      setClickedAnswer(index);
       await answerQuestion(
         triviaId,
-        currentQuestionIndex,
+        trivia.currentQuestionIndex || 0,
         user,
         index,
         new Date().getTime()
       );
     } catch (error) {
       setAnswerError(error as Error);
-      setAnsweredIndex(null);
     }
   };
 
-  const handleSetAnswerStartTime = async (answerStartTime: number) =>
-    currentQuestionIndex != null &&
-    (await setAnswerStartTime(
+  const handleSetAnswerStartTime = async (answerStartTime: number) => {
+    await setAnswerStartTime(
       triviaId,
-      currentQuestionIndex,
+      trivia.currentQuestionIndex || 0,
       user,
       answerStartTime
-    ));
+    );
+  };
 
-  return completed ? (
-    <QuestionResult {...{ trivia, user }} />
-  ) : (
-    <Nav>
-      <main className="question">
-        <section className="header">
-          <h1 className="title">{question?.question || ''}</h1>
-          <div className="in-progress-timer">
-            {currentQuestionIndex !== null && (
+  if (!completed) {
+    return (
+      <Nav>
+        <main className="question">
+          <section className="header">
+            <h1 className="title">{currentQuestion?.question}</h1>
+            <div className="in-progress-timer">
               <Timer
-                questionIndex={currentQuestionIndex}
-                startTime={selectedAnswerStartTime}
+                questionIndex={trivia.currentQuestionIndex}
+                startTime={answerStartTime}
                 timePerQuestion={trivia.timePerQuestion}
                 setCompleted={setCompleted}
                 setStartTime={handleSetAnswerStartTime}
               />
-            )}
-          </div>
-        </section>
-        {!!question && question.attachment && (
-          <Attachment value={question.attachment} />
-        )}
-        <Error error={answerError} />
-        <div className="options">
-          {!!question &&
-            currentQuestionIndex !== null &&
-            question.possibleAnswers.map((possibleAnswer, index) => (
-              <AnswerButton
+            </div>
+          </section>
+          {currentQuestion?.attachment && <Attachment value={currentQuestion.attachment} />}
+          <Error error={answerError || null} />
+          <div className="options">
+            {currentQuestion?.possibleAnswers.map((possibleAnswer, index) => (
+              <Answer
                 key={index}
                 possibleAnswer={possibleAnswer}
-                answered={answeredIndex !== null}
-                selected={answeredIndex === index}
+                answered={clickedAnswer !== null || selectedAnswerIndex !== null}
+                selected={(selectedAnswerIndex !== null ? selectedAnswerIndex : clickedAnswer) === index}
                 selectOption={() => selectOption(index)}
               />
             ))}
-        </div>
-      </main>
-    </Nav>
-  );
+          </div>
+        </main>
+      </Nav>
+    );
+  } else {
+    return <QuestionResult {...{ trivia, triviaId, user }} />;
+  }
 };
 
 export default InProgress;

--- a/apps/www/src/app/play/QuestionResult/index.tsx
+++ b/apps/www/src/app/play/QuestionResult/index.tsx
@@ -22,7 +22,7 @@ const QuestionResult = ({
   useEffect(() => {
     const participantUser = participants[user.uid];
     const selectedAnswer =
-      currentQuestionIndex || currentQuestionIndex === 0
+      (currentQuestionIndex !== null && participantUser)
         ? participantUser.answers[currentQuestionIndex]
         : null;
     const newMessage =

--- a/apps/www/src/app/play/host-question-result.tsx
+++ b/apps/www/src/app/play/host-question-result.tsx
@@ -3,9 +3,7 @@ import { TriviaHostQuestionResultProps } from './symbols';
 import Chart from 'react-google-charts';
 import { goToNextQuestion } from '../shared/trivias.service';
 import { Button } from '@material-ui/core';
-import { buildAnswer, buildQuestion } from '../shared/question';
 import {
-  Answer,
   Participants,
   Question,
   Trivia,
@@ -88,7 +86,7 @@ const HostQuestionResult = ({
           data={chartData}
         />
       )}
-      {question?.correctAnswerIndex && (
+      {!!question && question.correctAnswerIndex !== null && (
         <h1>
           {`Correct answer: ${
             question.possibleAnswers[question.correctAnswerIndex]

--- a/apps/www/src/app/play/joining/index.tsx
+++ b/apps/www/src/app/play/joining/index.tsx
@@ -84,7 +84,7 @@ const Joining = ({ trivia, user, triviaId }: TriviaJoiningProps) => {
           </h3>
           <List>
             {participants.map((participant) => (
-              <ListItemTriviaParticipant participant={participant} />
+              <ListItemTriviaParticipant key={participant.email} participant={participant} />
             ))}
           </List>
         </aside>


### PR DESCRIPTION
### Changes:
* Avoided double update on `updateParticipantAnswers` from `trivias.service`.
* Refactored component's logics on `InProgress` in order to manage state changes.

### How to test:
1. Start a trivia as a host.
2. Join that trivia with other user.
3. Join trivia with same user on a new private or incognito window.
4. Select an answer in step 2 window.
5. Select an answer in step 3 window.
6. Since there is a delay between the update requested in 4 and the updated state, you still could select other answer in 5, while that delay, but the final answer will be the selected in 4.

### Technical debt:
Same participant could not change selected answer from other device, but can still click on other answer since he still hasn't received confirmation that the update was done, even when the registered answer is the previous one.