### PR TITLE
Fix(play): fixing friendly name generation

### DIFF
--- a/apps/www/src/app/shared/generate-friendly-name.ts
+++ b/apps/www/src/app/shared/generate-friendly-name.ts
@@ -1,4 +1,6 @@
-const getRandomString = async () => Math.random().toString(16).substring(2, 16);
+
+import { getFunctions, httpsCallable } from 'firebase/functions';
+// const getRandomString = async () => Math.random().toString(16).substring(2, 16).concat("_", "friendly").concat("_", "name");
 
 /** TODO
  * Solved adding async function returning random string.
@@ -14,9 +16,11 @@ const getRandomString = async () => Math.random().toString(16).substring(2, 16);
  *   return result.data;
  */
 const generateFriendlyName = async (): Promise<string> => {
-  const data = await getRandomString();
-
-  return data;
+  const functions = getFunctions();
+  const result = await httpsCallable(functions, 'generateFriendlyName')();
+  return typeof result.data === 'string'
+    ? result.data
+    : '';
 };
 
 export default generateFriendlyName;

--- a/apps/www/src/app/shared/generate-friendly-name.ts
+++ b/apps/www/src/app/shared/generate-friendly-name.ts
@@ -1,26 +1,9 @@
-
 import { getFunctions, httpsCallable } from 'firebase/functions';
-// const getRandomString = async () => Math.random().toString(16).substring(2, 16).concat("_", "friendly").concat("_", "name");
 
-/** TODO
- * Solved adding async function returning random string.
- * When functions/ folder (under apps/) has been added by the right way,
- * we could use getFunctions and httpCallable to use generateFriendlyName.
- *
- *   import { getFunctions, httpsCallable } from 'firebase/functions';
- *
- *   ...
- *
- *   const functions = getFunctions();
- *   const result = await httpsCallable(functions, 'generateFriendlyName')();
- *   return result.data;
- */
 const generateFriendlyName = async (): Promise<string> => {
   const functions = getFunctions();
   const result = await httpsCallable(functions, 'generateFriendlyName')();
-  return typeof result.data === 'string'
-    ? result.data
-    : '';
+  return typeof result.data === 'string' ? result.data : '';
 };
 
 export default generateFriendlyName;


### PR DESCRIPTION
## Description
Fix(play): fixing friendly name generation

## 🖼️ Screen Captures

![image](https://user-images.githubusercontent.com/6662729/180067914-39129b8c-a574-469a-96b4-e58f8f08dfa4.png)
![image](https://user-images.githubusercontent.com/6662729/180068001-a68f57b9-bc98-4532-a495-e91221e014d5.png)


## 🧪 Testing Steps

1.Create a new trivia
2. Use friendly name to Join.
3. It should be the same as using triviaId

## 💡 Reference/Related Issues

- https://github.com/cloudx-labs/cuarentrivia/issues/107

## 📝 Checklist

- [ ] Tests have been added that prove my fix is effective or that my feature works
- [ ] Relevant README files and documentation have been updated
